### PR TITLE
feat: add firebase auth and user storage

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,22 @@
+import { auth } from './firebase-config.js';
+import { onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, sendPasswordResetEmail, signOut } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
+
+export function onAuthState(cb){
+  return onAuthStateChanged(auth, cb);
+}
+
+export function signIn(email, pass){
+  return signInWithEmailAndPassword(auth, email, pass);
+}
+
+export function signUp(email, pass){
+  return createUserWithEmailAndPassword(auth, email, pass);
+}
+
+export function resetPassword(email){
+  return sendPasswordResetEmail(auth, email);
+}
+
+export function signOutUser(){
+  return signOut(auth);
+}

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,16 @@
+export const firebaseConfig = {
+  apiKey: "___API_KEY___",
+  authDomain: "___AUTH_DOMAIN___",
+  projectId: "___PROJECT_ID___",
+  storageBucket: "___STORAGE_BUCKET___",
+  messagingSenderId: "___SENDER_ID___",
+  appId: "___APP_ID___"
+};
+
+import { initializeApp } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js";
+import { getAuth } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
+import { getFirestore } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
+
+export const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/firebase.rules
+++ b/firebase.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId}/decks/{deckId}/cards/{cardId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
 <meta name="mobile-web-app-capable" content="yes" />
 <link rel="manifest" href="manifest.json"><!-- opcional; falha segura se ausente -->
 <title>Flashcards (Romaji ↔ PT)</title>
+<script type="module" src="./firebase-config.js"></script> <!-- ADDED -->
+<script type="module" src="./auth.js"></script> <!-- ADDED -->
+<script type="module" src="./store.js"></script> <!-- ADDED -->
 <style>
   :root{
     color-scheme: dark;
@@ -32,6 +35,7 @@
   header,.card,.tabs,.section{width:100%; max-width:var(--maxw)}
   header{display:flex; align-items:center; justify-content:space-between; gap:8px; padding:8px 4px}
   .brand{font-weight:800; color:var(--text); font-size:18px}
+  .account{display:flex; align-items:center; gap:8px; color:var(--muted); font-weight:700} /* ADDED */
 
   /* 5 abas (inclui Reforço) */
   .tabs{display:grid; grid-template-columns:repeat(5,1fr); gap:8px}
@@ -65,6 +69,7 @@
 
   .btn{height:52px; padding:0 16px; border-radius:14px; font-weight:800; border:1px solid rgba(255,255,255,.08); background:var(--duo); color:#05121d; cursor:pointer}
   .btn.secondary{background:#1f2937; color:#e7eef7}
+  .btn.small{height:32px; padding:0 12px;} /* ADDED */
   .btn:disabled{opacity:.5; cursor:not-allowed}
   .btn:focus, .choice:focus, .audioBtn:focus {outline:3px solid rgba(67,182,255,.6); outline-offset:2px}
 
@@ -120,7 +125,11 @@
 <div class="app" id="app">
   <header>
     <div class="brand">Flashcards — Romaji ↔ PT</div>
-    <div class="helper" id="streak">Streak: 0</div>
+    <div class="account"> <!-- ADDED -->
+      <div class="helper" id="streak">Streak: 0</div>
+      <span id="userEmail"></span> <!-- ADDED -->
+      <button id="btnSignOut" class="btn secondary small">Sair</button> <!-- ADDED -->
+    </div> <!-- ADDED -->
   </header>
 
   <div class="tabs">
@@ -271,7 +280,9 @@
   <div class="msg" id="msg" style="display:none"></div>
 </div>
 
-<script>
+<script type="module"> <!-- ADDED -->
+import { onAuthState, signOutUser } from './auth.js'; // ADDED
+import { loadUserDeck, saveUserDeck, migrateFromLocalStorage } from './store.js'; // ADDED
   // ===== CONFIG =====
   const DATA_URL = './anime_romaji.json';
 
@@ -493,7 +504,7 @@ window.addEventListener('pointerdown', ensureAudio, {once:true});
   }
 
   // ===== STATE =====
-  let deck = loadDeckLS() || seed(defaultDeck);
+  let deck = []; // ADDED
   const State = { modeTab:'study', direction:'PT2ROMAJI', catFilter:'todas', current:null, lastCorrect:false };
   const Quiz = { direction:'PT2ROMAJI', cat:'todas', current:null, choices:[] };
   const Reinforce = { direction:'PT2ROMAJI', idx:0, order:[] };
@@ -919,13 +930,23 @@ window.addEventListener('pointerdown', ensureAudio, {once:true});
 
   // ===== INIT =====
   (async function init(){
-    deck = migrate(deck) || seed(defaultDeck);
-    await hydrateFromJson();
-    refreshCategoriesUI();
-    State.current = nextFromCycle('study', State.catFilter)
-    renderQuestion();
-    Quiz.cat='todas'; startQuizRound();
-    startReinforceRound();
+    onAuthState(async user=>{ // ADDED
+      if(!user){ window.location.href = './login.html'; return; } // ADDED
+      const uid = user.uid; // ADDED
+      const shortEmail = (user.email||'').split('@')[0]; // ADDED
+      document.getElementById('userEmail').textContent = 'Olá, ' + shortEmail; // ADDED
+      document.getElementById('btnSignOut').addEventListener('click', async ()=>{ await signOutUser(); window.location.href='./login.html';}); // ADDED
+      await migrateFromLocalStorage(uid); // ADDED
+      deck = await loadUserDeck(uid); // ADDED
+      if(!deck.length){ deck = seed(defaultDeck); await saveUserDeck(uid, deck); } // ADDED
+      saveDeck = () => saveUserDeck(uid, deck); // ADDED
+      await hydrateFromJson();
+      refreshCategoriesUI();
+      State.current = nextFromCycle('study', State.catFilter)
+      renderQuestion();
+      Quiz.cat='todas'; startQuizRound();
+      startReinforceRound();
+    }); // ADDED
   })();
 
   // ===== PWA (opcional, falha segura) =====

--- a/login.html
+++ b/login.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no" />
+<title>Login - Flashcards JP↔PT</title>
+<style>
+  :root{
+    color-scheme: dark;
+    --bg:#0b0f14; --card:#111827; --muted:#9fb3c8; --text:#e7eef7;
+    --accent:#43b6ff; --duo:#2bd463;
+  }
+  body{margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif; background:var(--bg); color:var(--text); display:flex; align-items:center; justify-content:center; min-height:100vh;}
+  .wrap{width:100%; max-width:420px; padding:20px; display:flex; flex-direction:column; gap:16px;}
+  h1{text-align:center; margin:0 0 10px;}
+  .tabs{display:flex; gap:8px;}
+  .tab{flex:1; padding:10px; text-align:center; background:#1f2937; color:var(--text); border:none; border-radius:8px; font-weight:700; cursor:pointer;}
+  .tab.active{background:var(--duo); color:#05121d;}
+  form{display:flex; flex-direction:column; gap:12px;}
+  input{height:48px; padding:0 12px; border-radius:8px; border:1px solid #223047; background:#0f1422; color:var(--text); font-size:16px;}
+  button.action{height:48px; border-radius:8px; border:none; font-weight:700; cursor:pointer; background:var(--duo); color:#05121d;}
+  button.link{background:none; border:none; color:var(--accent); font-weight:700; cursor:pointer; padding:0;}
+  #msg{min-height:20px; text-align:center; color:var(--accent); font-weight:700;}
+</style>
+<script type="module" src="./firebase-config.js"></script>
+<script type="module" src="./auth.js"></script>
+</head>
+<body>
+<div class="wrap">
+  <h1>Flashcards JP↔PT</h1>
+  <div class="tabs">
+    <button class="tab active" data-tab="signin">Entrar</button>
+    <button class="tab" data-tab="signup">Criar conta</button>
+  </div>
+  <div id="signin" class="panel">
+    <form id="formSignIn">
+      <input type="email" id="inEmail" placeholder="E-mail" required>
+      <input type="password" id="inPass" placeholder="Senha" required minlength="6">
+      <button class="action" type="submit">Entrar</button>
+      <button class="link" type="button" id="btnReset">Recuperar senha</button>
+    </form>
+  </div>
+  <div id="signup" class="panel" style="display:none">
+    <form id="formSignUp">
+      <input type="email" id="upEmail" placeholder="E-mail" required>
+      <input type="password" id="upPass" placeholder="Senha" required minlength="6">
+      <button class="action" type="submit">Criar conta</button>
+    </form>
+  </div>
+  <div id="msg" aria-live="polite"></div>
+</div>
+<script type="module">
+import { signIn, signUp, resetPassword, onAuthState } from './auth.js';
+
+onAuthState(user => { if(user) window.location.href = './index.html'; });
+
+const tabs = document.querySelectorAll('.tab');
+tabs.forEach(btn => btn.addEventListener('click', () => {
+  tabs.forEach(b => b.classList.remove('active'));
+  document.querySelectorAll('.panel').forEach(p => p.style.display = 'none');
+  btn.classList.add('active');
+  document.getElementById(btn.dataset.tab).style.display = 'block';
+}));
+
+const msg = document.getElementById('msg');
+function showMsg(t){ msg.textContent = t; }
+
+document.getElementById('formSignIn').addEventListener('submit', async e => {
+  e.preventDefault();
+  const email = document.getElementById('inEmail').value;
+  const pass = document.getElementById('inPass').value;
+  try{
+    await signIn(email, pass);
+    window.location.href = './index.html';
+  }catch(err){
+    showMsg(err.message);
+  }
+});
+
+document.getElementById('formSignUp').addEventListener('submit', async e => {
+  e.preventDefault();
+  const email = document.getElementById('upEmail').value;
+  const pass = document.getElementById('upPass').value;
+  try{
+    await signUp(email, pass);
+    window.location.href = './index.html';
+  }catch(err){
+    showMsg(err.message);
+  }
+});
+
+document.getElementById('btnReset').addEventListener('click', async () => {
+  const email = document.getElementById('inEmail').value;
+  if(!email){ showMsg('Informe seu e-mail.'); return; }
+  try{
+    await resetPassword(email);
+    showMsg('Email enviado.');
+  }catch(err){
+    showMsg(err.message);
+  }
+});
+</script>
+</body>
+</html>

--- a/store.js
+++ b/store.js
@@ -1,0 +1,61 @@
+import { db } from './firebase-config.js';
+import { collection, doc, getDocs, writeBatch, onSnapshot } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
+
+const CACHE_PREFIX = 'romajiDeck_cache_';
+
+export async function loadUserDeck(uid){
+  try{
+    const colRef = collection(db, `users/${uid}/decks/default/cards`);
+    const snap = await getDocs(colRef);
+    const deck = [];
+    snap.forEach(d=>deck.push(d.data()));
+    localStorage.setItem(`${CACHE_PREFIX}${uid}`, JSON.stringify(deck));
+    return deck;
+  }catch(e){
+    try{
+      const cached = JSON.parse(localStorage.getItem(`${CACHE_PREFIX}${uid}`));
+      if(Array.isArray(cached)) return cached;
+    }catch(_){}
+    return [];
+  }
+}
+
+export async function saveUserDeck(uid, deck){
+  const colRef = collection(db, `users/${uid}/decks/default/cards`);
+  const batch = writeBatch(db);
+  deck.forEach(card=>{
+    const ref = doc(colRef, card.id);
+    batch.set(ref, card, {merge:true});
+  });
+  await batch.commit();
+  localStorage.setItem(`${CACHE_PREFIX}${uid}`, JSON.stringify(deck));
+}
+
+export function watchUserDeck(uid, cb){
+  const colRef = collection(db, `users/${uid}/decks/default/cards`);
+  return onSnapshot(colRef, snap=>{
+    const deck=[];
+    snap.forEach(d=>deck.push(d.data()));
+    localStorage.setItem(`${CACHE_PREFIX}${uid}`, JSON.stringify(deck));
+    cb(deck);
+  });
+}
+
+export async function migrateFromLocalStorage(uid){
+  let deck = [];
+  try{
+    const raw = JSON.parse(localStorage.getItem('romajiDeck_v8'));
+    if(Array.isArray(raw) && raw.length){
+      await saveUserDeck(uid, raw);
+      localStorage.removeItem('romajiDeck_v8');
+      deck = raw;
+    }
+  }catch(e){}
+  if(!deck.length){
+    try{
+      const cached = JSON.parse(localStorage.getItem(`${CACHE_PREFIX}${uid}`));
+      if(Array.isArray(cached)) deck = cached;
+    }catch(e){}
+  }
+  return deck;
+}


### PR DESCRIPTION
## Summary
- add Firebase config placeholders and helpers
- integrate auth and Firestore storage with migration
- create login page and Firestore security rules

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/JP-MOBILE/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689e441f33248321b0ec3eb576936bda