### PR TITLE
fix: remove invalid HTML comment from module script

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
   <div class="msg" id="msg" style="display:none"></div>
 </div>
 
-<script type="module"> <!-- ADDED -->
+<script type="module">
 import { onAuthState, signOutUser } from './auth.js'; // ADDED
 import { loadUserDeck, saveUserDeck, migrateFromLocalStorage } from './store.js'; // ADDED
   // ===== CONFIG =====


### PR DESCRIPTION
## Summary
- fix SyntaxError by removing HTML comment inside module script

## Testing
- `node --check auth.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4ac94ba08321b2c1a4dc0afa2ac4