### PR TITLE
feat(sync): offline-first queue draining and improved sync button

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,7 +331,8 @@ import {
   upsertMany,
   cacheDeck,
   deleteMany,
-  markDeletedRomajiMany
+  markDeletedRomajiMany,
+  drainQueues
 } from './store.js';
 
   // ===== CONFIG =====
@@ -564,7 +565,11 @@ import {
     upserts: new Set()     // ids modificados/novos
   };
   function refreshPending(){
-    const n = Pending.deletions.size + Pending.tombs.size + Pending.upserts.size;
+    const uid = window.CURRENT_UID;
+    const qU = JSON.parse(localStorage.getItem('romajiDeck_q_upserts_'+uid) || '[]').length;
+    const qD = JSON.parse(localStorage.getItem('romajiDeck_q_deletes_'+uid) || '[]').length;
+    const qT = JSON.parse(localStorage.getItem('romajiDeck_q_tombs_'+uid)  || '[]').length;
+    const n = Pending.deletions.size + Pending.tombs.size + Pending.upserts.size + qU + qD + qT;
     const lbl = document.getElementById('pendingLbl');
     if(lbl) lbl.textContent = `Alterações pendentes: ${n}`;
   }
@@ -1230,6 +1235,13 @@ import {
       }
 
       await hydrateFromJson();
+      try {
+        await drainQueues(uid);       // tenta enviar o que ficou pendente de sessões anteriores
+      } catch(e) {
+        // Se quota estourou, mantemos tudo offline e tentamos depois
+        console.warn('Sync adiada (provável quota):', e);
+        toast('Sem quota agora. Suas alterações estão salvas offline.');
+      }
       refreshCategoriesUI();
       State.current = nextFromCycle('study', State.catFilter);
       renderQuestion();
@@ -1244,24 +1256,32 @@ import {
     const uid = window.CURRENT_UID;
     if(!uid){ toast('Você precisa estar logado.'); return; }
     try{
+      // 1) envia o que foi alterado nesta sessão
       const upsertList = deck.filter(c => Pending.upserts.has(String(c.id)));
       if (upsertList.length) await upsertMany(uid, upsertList);
-
       const delIds = [...Pending.deletions];
       if (delIds.length) await deleteMany(uid, delIds);
-
       const tombs = [...Pending.tombs];
       if (tombs.length) await markDeletedRomajiMany(uid, tombs);
 
+      // 2) envia também o que já estava pendente de sessões anteriores
+      await drainQueues(uid);
+
+      // 3) limpa pendências locais de UI
       Pending.deletions.clear();
       Pending.tombs.clear();
       Pending.upserts.clear();
       refreshPending();
-      try{ localStorage.removeItem('unsynced'); }catch(_){}
-      toast('Sincronizado com o servidor!');
+      toast('Sincronizado!');
     }catch(e){
       console.error(e);
-      toast('Erro ao sincronizar: ' + (e.code || e.message || 'desconhecido'));
+      if (String(e?.code||e?.message).includes('resource-exhausted')){
+        // salva offline e tenta depois
+        try{ localStorage.setItem('unsynced','1'); }catch(_){ }
+        toast('Cota da Firestore esgotada. Alterações salvas offline.');
+      } else {
+        toast('Erro ao sincronizar: ' + (e.message || e));
+      }
     }
   });
 

--- a/store.js
+++ b/store.js
@@ -290,12 +290,15 @@ export async function migrateFromLocalStorage(uid){
 // (Opcional) tentar drenar as filas
 // ===========================
 export async function drainQueues(uid){
-  const up = readLS(Q_UPSERT+uid, []);
-  const del = readLS(Q_DELETE+uid, []);
-  const tb = readLS(Q_TOMBS+uid, []);
+  const up = JSON.parse(localStorage.getItem('romajiDeck_q_upserts_'+uid) || '[]');
+  const del = JSON.parse(localStorage.getItem('romajiDeck_q_deletes_'+uid) || '[]');
+  const tb  = JSON.parse(localStorage.getItem('romajiDeck_q_tombs_'+uid)  || '[]');
   if(up.length) await upsertMany(uid, up);
   if(del.length) await deleteMany(uid, del);
   if(tb.length)  await markDeletedRomajiMany(uid, tb);
-  const left = readLS(Q_UPSERT+uid, []).length + readLS(Q_DELETE+uid, []).length + readLS(Q_TOMBS+uid, []).length;
-  if(left===0) try{ localStorage.removeItem('unsynced'); }catch(_){}
+  const left =
+    (JSON.parse(localStorage.getItem('romajiDeck_q_upserts_'+uid) || '[]').length) +
+    (JSON.parse(localStorage.getItem('romajiDeck_q_deletes_'+uid) || '[]').length) +
+    (JSON.parse(localStorage.getItem('romajiDeck_q_tombs_'+uid)  || '[]').length);
+  if(left===0) try{ localStorage.removeItem('unsynced'); }catch(_){ }
 }


### PR DESCRIPTION
## Summary
- add `drainQueues` to store for flushing localStorage queues and clearing unsynced flag
- sync UI counts local and session queues and sends both when syncing
- attempt to drain queues on init and show quota toast if exhausted

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e923160c883218e3da5281bde2980